### PR TITLE
nowMinが一桁のときは数値の前に0を追加して表示するよう修正

### DIFF
--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -46,7 +46,7 @@ public class Main {
     int nowMin = nowTime.getMinute();
 
 //    以下、動作確認用
-//
+
 //    int nowHour = 0;
 //    int nowMin = 0;
 //
@@ -60,9 +60,9 @@ public class Main {
 //    int nowMin = 59;
 
     if(nowHour < 12){
-      System.out.println("AM"+nowHour+":"+nowMin);
+      System.out.println("AM "+nowHour+":"+(nowMin < 10 ? "0" + nowMin : "0"));
     }else{
-      System.out.println("PM"+nowHour+":"+nowMin);
+      System.out.println("PM "+nowHour+":"+(nowMin < 10 ? "0" + nowMin : "0"));
     }
   }
 }


### PR DESCRIPTION
# 概要
・現在時刻の分が１桁の場合、表示が「AM 〇〇:◯」となっており不自然だったため、「AM 〇〇:０〇」となるように修正する。

# 修正内容
・nowMinが10より小さいなら、分の数値の前に”0” を追加する三項演算子を追加する。

# 動作確認
・0時0分の場合<br>
<img width="201" alt="image" src="https://github.com/masehideki/New-Java-5/assets/135149708/710419bc-0503-46a4-a66d-ca726a66ad78">

・12時0分の場合<br>
<img width="176" alt="image" src="https://github.com/masehideki/New-Java-5/assets/135149708/8d89d61e-0c95-4a2a-b1bb-5168bc121c3c">
